### PR TITLE
Update ACLController.js

### DIFF
--- a/www/app/controller/ACLController.js
+++ b/www/app/controller/ACLController.js
@@ -147,7 +147,7 @@ Ext.define('Rubedo.controller.ACLController', {
                         Ext.getCmp("ViewportPrimaire").insert(0,Ext.widget("simpleModeMainBar"));
                     }
                 });
-                task.delay(300);
+                task.delay(2000);
             },
             failure:function(){
                 Ext.Msg.alert(Rubedo.RubedoAutomatedElementsLoc.errorTitle, Rubedo.RubedoAutomatedElementsLoc.rightsRecoveryError);


### PR DESCRIPTION
Longer delay until showing top menu-bar fixes slow initialization. Problem is that MyPrefData.simpleMode will be set too late dynamically while loading user-profile. the trigger task.delay(300) can be executed before profile is ready. Setting delay to 2000 is a workaround for me.
