### PR TITLE
bugfix icons or favorites dont maximize

### DIFF
--- a/www/app/controller/InterfaceController.js
+++ b/www/app/controller/InterfaceController.js
@@ -737,6 +737,11 @@ Ext.define('Rubedo.controller.InterfaceController', {
                     if (Ext.isDefined(fenetre)){fenetre.show();  fenetre.toFront(); }
                     else {
                         fenetre = Ext.widget(action.target);
+                        if (MyPrefData.simpleMode){
+                            fenetre.maximized=true;
+                            fenetre.draggable=false;
+                        }
+
                         Ext.getCmp('desktopCont').add(fenetre);
                         if (Ext.isDefined(window.innerHeight)) {
                             if (fenetre.height>(window.innerHeight-40)) {fenetre.setHeight((window.innerHeight-40));}


### PR DESCRIPTION
Adding fenetre.maximized.true, will maximize windows correctly from favorites in simpleMode.
